### PR TITLE
Port to Zig package manager

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,52 +1,39 @@
 const std = @import("std");
 
-var _module: ?*std.build.Module = null;
-
-pub fn module(b: *std.Build) *std.build.Module {
-    if (_module) |m| return m;
-    _module = b.createModule(.{
-        .source_file = .{ .path = sdkPath("/src/main.zig") },
-    });
-    return _module.?;
-}
-
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
-    const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&testStep(b, optimize, target).step);
-}
 
-pub fn testStep(b: *std.Build, optimize: std.builtin.OptimizeMode, target: std.zig.CrossTarget) *std.build.RunStep {
-    const main_tests = b.addTest(.{
-        .name = "model3d-tests",
-        .root_source_file = .{ .path = sdkPath("/src/main.zig") },
-        .target = target,
-        .optimize = optimize,
-    });
-    link(b, main_tests, target);
-    main_tests.install();
-    return main_tests.run();
-}
-
-pub fn link(b: *std.Build, step: *std.build.CompileStep, target: std.zig.CrossTarget) void {
     const lib = b.addStaticLibrary(.{
         .name = "model3d",
         .target = target,
-        .optimize = step.optimize,
+        .optimize = optimize,
     });
+
+    lib.linkLibC();
+    lib.addIncludePath("src/c");
+
     // Note: model3d needs unaligned accesses, which are safe on all modern architectures.
     // See https://gitlab.com/bztsrc/model3d/-/issues/19
-    lib.addCSourceFile(sdkPath("/src/c/m3d.c"), &.{ "-std=c89", "-fno-sanitize=alignment" });
-    lib.linkLibC();
-    step.addIncludePath(sdkPath("/src/c/"));
-    step.linkLibrary(lib);
-}
+    lib.addCSourceFile("src/c/m3d.c", &.{ "-std=c89", "-fno-sanitize=alignment" });
 
-fn sdkPath(comptime suffix: []const u8) []const u8 {
-    if (suffix[0] != '/') @compileError("suffix must be an absolute path");
-    return comptime blk: {
-        const root_dir = std.fs.path.dirname(@src().file) orelse ".";
-        break :blk root_dir ++ suffix;
-    };
+    // TODO: add a dependency on libmodel3d here once supported
+    _ = b.addModule("mach-model3d", .{
+        .source_file = .{ .path = "src/main.zig" },
+    });
+
+    const main_tests = b.addTest(.{
+        .name = "model3d-tests",
+        .root_source_file = .{ .path = "src/main.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+
+    main_tests.linkLibrary(lib);
+    main_tests.addIncludePath("src/c");
+
+    main_tests.install();
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&b.addRunArtifact(main_tests).step);
 }

--- a/build.zig
+++ b/build.zig
@@ -17,6 +17,8 @@ pub fn build(b: *std.Build) void {
     // See https://gitlab.com/bztsrc/model3d/-/issues/19
     lib.addCSourceFile("src/c/m3d.c", &.{ "-std=c89", "-fno-sanitize=alignment" });
 
+    b.installArtifact(lib);
+
     // TODO: add a dependency on libmodel3d here once supported
     _ = b.addModule("mach-model3d", .{
         .source_file = .{ .path = "src/main.zig" },
@@ -31,8 +33,6 @@ pub fn build(b: *std.Build) void {
 
     main_tests.linkLibrary(lib);
     main_tests.addIncludePath("src/c");
-
-    main_tests.install();
 
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&b.addRunArtifact(main_tests).step);


### PR DESCRIPTION
The mach-model3d module currently will not build outside this repository as it will not link libmodel3d.

I'll update once we get something along the lines of ziglang/zig#14731